### PR TITLE
Support exporting compiled template as AMD module

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,12 +29,19 @@ var createHandlebarsPreprocessor = function(args, config, logger) {
 
     var template = templateName(file.originalPath);
 
-    try {
-      processed = "(function() {" + templates + " = " + templates + " || {};" +
-        templates + "['" + template + "'] = Handlebars.template(" +
-        handlebars.precompile(content) + ");})();";
-    } catch (e) {
-      log.error('%s\n  at %s', e.message, file.originalPath);
+    if(config.amd) {
+      processed = "define(['handlebars'], function(Handlebars) {\n" +
+                  "    return Handlebars.template(" + handlebars.precompile(content)  + ");\n" +
+                  "});"
+
+    } else {
+      try {
+        processed = "(function() {" + templates + " = " + templates + " || {};" +
+            templates + "['" + template + "'] = Handlebars.template(" +
+            handlebars.precompile(content) + ");})();";
+      } catch (e) {
+        log.error('%s\n  at %s', e.message, file.originalPath);
+      }
     }
 
     done(processed);


### PR DESCRIPTION
If a config option of `amd` is set to `true`, then the compiled template is wrapped in an anonymous AMD module definition.

```
        handlebarsPreprocessor: {
            amd: true,
            templateName: function(file) {
                // name of AMD module should be name of template
                return file.replace(/^.*\/(view\/templates\/.*)\.hbs$/, "$1");
            }
        },
```